### PR TITLE
fix: :bug: entity keys to singular and add intent validation [AI]

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -311,7 +311,7 @@ wheels = [
 
 [[package]]
 name = "private-assistant-curtain-skill"
-version = "1.1.2"
+version = "2.0.1"
 source = { editable = "." }
 dependencies = [
     { name = "jinja2" },


### PR DESCRIPTION
- Standardize entity keys from plural to singular (room, number, device) matching intent classifier format
- Add _is_curtain_intent() validation to prevent interference with other skills (lights, locks, etc.)
- Enhance integration tests with realistic fictional data patterns (studio, office, garage)
- Add 5 new validation tests ensuring proper device intent filtering